### PR TITLE
feat: Change `arrowParens` rule from `avoid` to `always`

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/prettierrc",
   "singleQuote": true,
   "printWidth": 125,
   "trailingComma": "es5",
   "endOfLine": "lf",
-  "arrowParens": "avoid"
+  "arrowParens": "always"
 }


### PR DESCRIPTION
BREAKING CHANGE: This changes the default syntax of arrow functions, adjust your code accordingly.