### PR TITLE
feat: Upgrade prettier to version 2

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,8 +1,4 @@
 {
-  "$schema": "http://json.schemastore.org/prettierrc",
   "singleQuote": true,
-  "printWidth": 125,
-  "trailingComma": "es5",
-  "endOfLine": "lf",
-  "arrowParens": "avoid"
+  "printWidth": 125
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "semantic-release": "^15.13.16"
   },
   "peerDependencies": {
-    "prettier": ">=1.15.0 <3.0.0"
+    "prettier": "^2.0.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
BREAKING CHANGE: The default behaviour of `arrowParens` rule changed from `avoid` to `always`. Make sure to update your code accordingly.